### PR TITLE
Fix for coverage problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,18 +3,19 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/jest --config ./jest.config.json --coverage"
+    "test": "rimraf coverage/**/* && jest --config ./jest.config.json --coverage --no-cache"
   },
   "author": "",
   "license": "ISC",
   "description": "",
   "devDependencies": {
     "enzyme": "^2.4.1",
-    "jest": "^16.0.1",
+    "jest": "^16.0.2",
     "react": "^15.3.2",
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.3.2",
     "ts-jest": "^0.1.11",
-    "typescript": "^2.0.6"
+    "typescript": "^2.0.6",
+    "rimraf": "^2.5.4"
   }
 }

--- a/specs/components/test.component.spec.tsx
+++ b/specs/components/test.component.spec.tsx
@@ -11,7 +11,7 @@ describe('TestComponent', () => {
       const wrapper = shallow(<TestComponent />);
 
       expect(wrapper.html()).toEqual('<div></div>');
-      setTimeout(() => done, jasmine.DEFAULT_TIMEOUT_INTERVAL - 1);
+      setTimeout(done, jasmine.DEFAULT_TIMEOUT_INTERVAL - 1000);
     });
 
   });

--- a/specs/components/test2.component.spec.tsx
+++ b/specs/components/test2.component.spec.tsx
@@ -11,7 +11,7 @@ describe('TestComponent', () => {
       const wrapper = shallow(<TestComponent />);
 
       expect(wrapper.html()).toEqual('<div></div>');
-      setTimeout(() => done, jasmine.DEFAULT_TIMEOUT_INTERVAL);
+      setTimeout(done, jasmine.DEFAULT_TIMEOUT_INTERVAL);
     });
 
   });


### PR DESCRIPTION
Due to https://github.com/kulshekhar/ts-jest/issues/43. After a lot of investigation done for this issue - I can say that it doesn't seem to be a problem of `ts-jest`.
At first I thought that problem caused by async tests, but it's not a case. I've even added tests for this case https://github.com/kulshekhar/ts-jest/commit/f8e6f9be4f65bc3a1c33930af99453f03a622b6b.
Then I checked `enzyme` package, because it manipulates `global` object, but it's not a case too.
So this problem could be only with Jest's cache.

Just try to reinstall `node_modules` and always use `coverageprocessor` with `--no-cache` option.
If it won't help, try to invalidate cache by running tests with changed source and `--no-cache` flag.
And last, remapped coverage could appear in `./coverage/remapped` instead of `./coverage`.